### PR TITLE
npm: add package name to package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "aria-query",
       "version": "5.0.0",
       "license": "Apache-2.0",
       "devDependencies": {


### PR DESCRIPTION
Performing an 'npm install' with npm 8.3.1 and node 16.14.0 introduces a
small change to the lockfile that should be committed. Update
package-lock.json after the current package's name is added.